### PR TITLE
Adding endpoint for persisting lists

### DIFF
--- a/server/src/main/java/com/wedo/wedo/controller/ListController.java
+++ b/server/src/main/java/com/wedo/wedo/controller/ListController.java
@@ -1,7 +1,7 @@
 package com.wedo.wedo.controller;
 
 import com.wedo.wedo.dto.ListDto;
-import com.wedo.wedo.dto.TaskDto;
+import com.wedo.wedo.repository.ListRepository;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,8 +9,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ListController {
 
+    private final ListRepository repository;
+
+    ListController(ListRepository repository) {
+        this.repository = repository;
+    }
+
+
     @PostMapping("/v1/lists")
     ListDto newList(@RequestBody ListDto listDto) {
-        return listDto;
+        return repository.save(listDto);
     }
 }

--- a/server/src/main/java/com/wedo/wedo/controller/ListController.java
+++ b/server/src/main/java/com/wedo/wedo/controller/ListController.java
@@ -1,15 +1,16 @@
 package com.wedo.wedo.controller;
 
+import com.wedo.wedo.dto.ListDto;
 import com.wedo.wedo.dto.TaskDto;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class TaskController {
+public class ListController {
 
-    @PostMapping("/v1/tasks")
-    TaskDto newTask(@RequestBody TaskDto taskDto) {
-        return taskDto;
+    @PostMapping("/v1/lists")
+    ListDto newList(@RequestBody ListDto listDto) {
+        return listDto;
     }
 }

--- a/server/src/main/java/com/wedo/wedo/dto/ListDto.java
+++ b/server/src/main/java/com/wedo/wedo/dto/ListDto.java
@@ -2,11 +2,15 @@ package com.wedo.wedo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
 import java.util.Objects;
 
+@Entity
 public class ListDto {
 
     @JsonProperty("list_id")
+    @Id
     private String listId;
 
     @JsonProperty("list_name")

--- a/server/src/main/java/com/wedo/wedo/dto/ListDto.java
+++ b/server/src/main/java/com/wedo/wedo/dto/ListDto.java
@@ -1,0 +1,52 @@
+package com.wedo.wedo.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class ListDto {
+
+    @JsonProperty("list_id")
+    private String listId;
+
+    @JsonProperty("list_name")
+    private String listName;
+
+    public String getListId() {
+        return listId;
+    }
+
+    public void setListId(String listId) {
+        this.listId = listId;
+    }
+
+    public String getListName() {
+        return listName;
+    }
+
+    public void setListName(String listName) {
+        this.listName = listName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListDto listDto = (ListDto) o;
+        return Objects.equals(listId, listDto.listId) &&
+                Objects.equals(listName, listDto.listName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(listId, listName);
+    }
+
+    @Override
+    public String toString() {
+        return "ListDto{" +
+                "listId='" + listId + '\'' +
+                ", listName='" + listName + '\'' +
+                '}';
+    }
+}

--- a/server/src/main/java/com/wedo/wedo/dto/TaskDto.java
+++ b/server/src/main/java/com/wedo/wedo/dto/TaskDto.java
@@ -2,6 +2,7 @@ package com.wedo.wedo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.persistence.Entity;
 import java.util.Objects;
 
 public class TaskDto {

--- a/server/src/main/java/com/wedo/wedo/repository/ListRepository.java
+++ b/server/src/main/java/com/wedo/wedo/repository/ListRepository.java
@@ -1,0 +1,8 @@
+package com.wedo.wedo.repository;
+
+import com.wedo.wedo.dto.ListDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ListRepository extends JpaRepository<ListDto, String> {
+
+}


### PR DESCRIPTION
Adding a basic endpoint for persisting lists.  Starting simple, with only a list id and a title.

Currently persisting the lists to H2, at some point will add a real database when we deploy this to a server